### PR TITLE
Adds license information to setup function

### DIFF
--- a/release.py
+++ b/release.py
@@ -20,6 +20,7 @@ MINOR       = 12
 MICRO       = 1
 DEV         = True
 DESCRIPTION = 'Enable to use scons within distutils to build extensions'
+LICENSE     = 'BSD 3-clause'
 CLASSIFIERS = filter(None, CLASSIFIERS.split('\n'))
 AUTHOR      = 'David Cournapeau'
 AUTHOR_EMAIL = 'david@ar.media.kyoto-u.ac.jp'

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(cmdclass = {'install': install, 'install_data': install_data, 'sdist': sdi
       name          = R.NAME,
       version       = R.build_fverstring(),
       description   = R.DESCRIPTION,
+      license       = R.LICENSE,
       author        = R.AUTHOR,
       author_email  = R.AUTHOR_EMAIL,
       packages      = R.PACKAGES,


### PR DESCRIPTION
Adds the license information, i.e BSD 3-clause, to release.py and using it in setup.py.
